### PR TITLE
Fix in Base.vb

### DIFF
--- a/VB.NET/ExceptionBase.NET/ExceptionBase.NET/Base.vb
+++ b/VB.NET/ExceptionBase.NET/ExceptionBase.NET/Base.vb
@@ -85,13 +85,13 @@ Public Class ExceptionBase
             Exception.Message = If(Not IsNothing(ex.Message), ex.Message, NOTAVAILABLE)
 
             ' Get the InnerException's message
-            Exception.Message = If(Not IsNothing(ex.InnerException), ex.InnerException.ToString, NOTAVAILABLE)
+            Exception.Inner = If(Not IsNothing(ex.InnerException), ex.InnerException.ToString, NOTAVAILABLE)
 
             ' Get the stack trace
-            Exception.Message = If(Not IsNothing(ex.StackTrace), ex.StackTrace, NOTAVAILABLE)
+            Exception.StackTrace = If(Not IsNothing(ex.StackTrace), ex.StackTrace, NOTAVAILABLE)
 
             ' Get the TargetSite
-            Exception.Message = If(Not IsNothing(ex.TargetSite), ex.TargetSite.ToString, NOTAVAILABLE)
+            Exception.TargetSite = If(Not IsNothing(ex.TargetSite), ex.TargetSite.ToString, NOTAVAILABLE)
         End If
     End Sub
 


### PR DESCRIPTION
GatherInformation assigned the InnerException.Message, the StackTrace and the TargetSite to Exception.Message to it was overwritten.
